### PR TITLE
Move towards simpler interfaces and good lifecycle management hygiene

### DIFF
--- a/internal/scripts/e2e_resume_test.rb
+++ b/internal/scripts/e2e_resume_test.rb
@@ -16,10 +16,10 @@ require 'logger'
 require 'securerandom'
 
 class ResumeTest
-  TOTAL_INSERTS = 3000
-  INSERTS_BEFORE_INTERRUPT = 1000
-  RESUME_WAIT_TIME = 2 # seconds
-  NUM_GROUPS = 3
+  TOTAL_INSERTS = 5000
+  INSERTS_BEFORE_INTERRUPT = 1500
+  RESUME_WAIT_TIME = 1 # seconds
+  NUM_GROUPS = 4
 
   PG_HOST = 'localhost'
   PG_PORT = 5433
@@ -284,7 +284,7 @@ class ResumeTest
     @logger.info "Waiting for all inserts to complete..."
     threads.each(&:join)
 
-    sleep 5
+    sleep 20
 
     @logger.info "Sending final SIGTERM to cleanup..."
     @replicator_pids.each do |pid|

--- a/internal/scripts/e2e_test_local.sh
+++ b/internal/scripts/e2e_test_local.sh
@@ -33,9 +33,9 @@ make build
 
 setup_docker
 
-log "Running e2e postgres tests..."
-if CI=false ./internal/scripts/e2e_postgres.sh; then
-  success "e2e postgres tests completed successfully"
+log "Running e2e ddl tests..."
+if CI=false ruby ./internal/scripts/e2e_resume_test.rb; then
+  success "e2e ddl tests completed successfully"
 else
   error "Original e2e tests failed"
   exit 1

--- a/pkg/replicator/base_replicator.go
+++ b/pkg/replicator/base_replicator.go
@@ -27,6 +27,7 @@ type BaseReplicator struct {
 	Config               Config
 	ReplicationConn      ReplicationConnection
 	StandardConn         StandardConnection
+	DDLReplicator        *DDLReplicator
 	Relations            map[uint32]*pglogrepl.RelationMessage
 	Logger               utils.Logger
 	TableDetails         map[string][]string
@@ -55,6 +56,15 @@ func NewBaseReplicator(config Config, replicationConn ReplicationConnection, sta
 		Logger:          logger,
 		TableDetails:    make(map[string][]string),
 		NATSClient:      natsClient,
+	}
+
+	if config.TrackDDL {
+		ddlRepl, err := NewDDLReplicator(config, br, standardConn)
+		if err != nil {
+			br.Logger.Error().Err(err).Msg("Failed to initialize DDL replicator")
+		} else {
+			br.DDLReplicator = ddlRepl
+		}
 	}
 
 	// Initialize the OID map with custom types from the database
@@ -470,10 +480,19 @@ func (r *BaseReplicator) CheckReplicationSlotExists(slotName string) (bool, erro
 func (r *BaseReplicator) GracefulShutdown(ctx context.Context) error {
 	r.Logger.Info().Msg("Initiating graceful shutdown")
 
+	// Send final status update before DDL shutdown
 	if err := r.SendStandbyStatusUpdate(ctx); err != nil {
 		r.Logger.Warn().Err(err).Msg("Failed to send final standby status update")
 	}
 
+	// Shutdown DDL replicator if it exists
+	if r.DDLReplicator != nil {
+		if err := r.DDLReplicator.Shutdown(ctx); err != nil {
+			r.Logger.Warn().Err(err).Msg("Failed to shutdown DDL replicator")
+		}
+	}
+
+	// Save state and close connections
 	if err := r.SaveState(r.LastLSN); err != nil {
 		r.Logger.Warn().Err(err).Msg("Failed to save final state")
 	}
@@ -490,12 +509,30 @@ func (r *BaseReplicator) GracefulShutdown(ctx context.Context) error {
 func (r *BaseReplicator) closeConnections(ctx context.Context) error {
 	r.Logger.Info().Msg("Closing database connections")
 
-	if err := r.ReplicationConn.Close(ctx); err != nil {
-		return fmt.Errorf("failed to close replication connection: %w", err)
+	// Close replication connection first
+	if r.ReplicationConn != nil {
+		if err := r.ReplicationConn.Close(ctx); err != nil {
+			r.Logger.Error().Err(err).Msg("Failed to close replication connection")
+		}
+		r.ReplicationConn = nil
 	}
-	if err := r.StandardConn.Close(ctx); err != nil {
-		return fmt.Errorf("failed to close standard connection: %w", err)
+
+	// Close standard connection
+	if r.StandardConn != nil {
+		if err := r.StandardConn.Close(ctx); err != nil {
+			r.Logger.Error().Err(err).Msg("Failed to close standard connection")
+		}
+		r.StandardConn = nil
 	}
+
+	// Close DDL connection if exists
+	if r.DDLReplicator != nil && r.DDLReplicator.DDLConn != nil {
+		if err := r.DDLReplicator.DDLConn.Close(ctx); err != nil {
+			r.Logger.Error().Err(err).Msg("Failed to close DDL connection")
+		}
+		r.DDLReplicator.DDLConn = nil
+	}
+
 	return nil
 }
 
@@ -542,20 +579,22 @@ func (r *BaseReplicator) Start(ctx context.Context) error {
 	r.stopChan = make(chan struct{})
 	r.mu.Unlock()
 
-	// Initialize connections
-	if err := r.ReplicationConn.Connect(ctx); err != nil {
-		return fmt.Errorf("failed to connect replication connection: %w", err)
-	}
-	if err := r.StandardConn.Connect(ctx); err != nil {
-		return fmt.Errorf("failed to connect standard connection: %w", err)
-	}
-
-	// Create publication and replication slot
+	// Create publication first (uses standard connection)
 	if err := r.CreatePublication(); err != nil {
 		return fmt.Errorf("failed to create publication: %w", err)
 	}
+
+	// Create replication slot (uses standard connection)
 	if err := r.CreateReplicationSlot(ctx); err != nil {
 		return fmt.Errorf("failed to create replication slot: %w", err)
+	}
+
+	// Setup and start DDL tracking if enabled
+	if r.Config.TrackDDL && r.DDLReplicator != nil {
+		if err := r.DDLReplicator.SetupDDLTracking(ctx); err != nil {
+			return fmt.Errorf("failed to setup DDL tracking: %w", err)
+		}
+		go r.DDLReplicator.StartDDLReplication(ctx)
 	}
 
 	return nil

--- a/pkg/replicator/errors.go
+++ b/pkg/replicator/errors.go
@@ -1,6 +1,15 @@
 package replicator
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrReplicatorAlreadyStarted = errors.New("replicator already started")
+	ErrReplicatorNotStarted     = errors.New("replicator not started")
+	ErrReplicatorAlreadyStopped = errors.New("replicator already stopped")
+)
 
 // ReplicationError represents an error that occurred during replication.
 type ReplicationError struct {

--- a/pkg/replicator/interfaces.go
+++ b/pkg/replicator/interfaces.go
@@ -12,7 +12,8 @@ import (
 )
 
 type Replicator interface {
-	StartReplication() error
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
 }
 
 type ReplicationConnection interface {

--- a/pkg/replicator/stream_replicator.go
+++ b/pkg/replicator/stream_replicator.go
@@ -27,6 +27,8 @@ func (r *StreamReplicator) Start(ctx context.Context) error {
 		startLSN = pglogrepl.LSN(0)
 	}
 
+	r.Logger.Info().Str("startLSN", startLSN.String()).Msg("Starting replication")
+
 	errChan := make(chan error, 1)
 	go func() {
 		errChan <- r.StartReplicationFromLSN(ctx, startLSN, r.stopChan)

--- a/pkg/replicator/stream_replicator.go
+++ b/pkg/replicator/stream_replicator.go
@@ -2,113 +2,44 @@ package replicator
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"os/signal"
-	"sync"
-	"syscall"
 
 	"github.com/jackc/pglogrepl"
 )
 
 type StreamReplicator struct {
-	BaseReplicator
-	DDLReplicator DDLReplicator
+	*BaseReplicator
 }
 
-// StartReplication begins the replication process.
-func (r *StreamReplicator) StartReplication() error {
-	ctx := context.Background()
+func NewStreamReplicator(base *BaseReplicator) *StreamReplicator {
+	return &StreamReplicator{
+		BaseReplicator: base,
+	}
+}
 
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-	if err := r.setup(ctx); err != nil {
+func (r *StreamReplicator) Start(ctx context.Context) error {
+	if err := r.BaseReplicator.Start(ctx); err != nil {
 		return err
 	}
 
-	startLSN, err := r.getStartLSN()
+	startLSN, err := r.GetLastState()
 	if err != nil {
-		return err
+		r.Logger.Warn().Err(err).Msg("Failed to get last LSN, starting from 0")
+		startLSN = pglogrepl.LSN(0)
 	}
 
-	r.Logger.Info().Str("startLSN", startLSN.String()).Msg("Starting replication from LSN")
-
-	// Start DDL replication with its own cancellable context and wait group
-	var ddlWg sync.WaitGroup
-	var ddlCancel context.CancelFunc
-	if r.Config.TrackDDL {
-		ddlCtx, cancel := context.WithCancel(ctx)
-		ddlCancel = cancel
-		if err := r.DDLReplicator.SetupDDLTracking(ctx); err != nil {
-			return fmt.Errorf("failed to set up DDL tracking: %v", err)
-		}
-		ddlWg.Add(1)
-		go func() {
-			defer ddlWg.Done()
-			r.DDLReplicator.StartDDLReplication(ddlCtx)
-		}()
-	}
-
-	stopChan := make(chan struct{})
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- r.BaseReplicator.StartReplicationFromLSN(ctx, startLSN, stopChan)
+		errChan <- r.StartReplicationFromLSN(ctx, startLSN, r.stopChan)
 	}()
 
 	select {
-	case <-sigChan:
-		r.Logger.Info().Msg("Received shutdown signal")
-		// Signal the replication loop to stop
-		close(stopChan)
-		// Wait for the replication loop to exit
-		<-errChan
-
-		// Signal DDL replication to stop and wait for it to finish
-		if r.Config.TrackDDL {
-			ddlCancel()
-			ddlWg.Wait()
-			if err := r.DDLReplicator.Shutdown(context.Background()); err != nil {
-				r.Logger.Error().Err(err).Msg("Failed to shutdown DDL replicator")
-			}
-		}
-
-		if err := r.BaseReplicator.GracefulShutdown(ctx); err != nil {
-			r.Logger.Error().Err(err).Msg("Error during graceful shutdown")
-			return err
-		}
+	case <-ctx.Done():
+		return ctx.Err()
 	case err := <-errChan:
-		if err != nil {
-			r.Logger.Error().Err(err).Msg("Replication ended with error")
-			return err
-		}
+		return err
 	}
-
-	return nil
 }
 
-func (r *StreamReplicator) setup(ctx context.Context) error {
-	if err := r.BaseReplicator.CreatePublication(); err != nil {
-		return fmt.Errorf("failed to create publication: %v", err)
-	}
-
-	if err := r.BaseReplicator.CreateReplicationSlot(ctx); err != nil {
-		return fmt.Errorf("failed to create replication slot: %v", err)
-	}
-
-	if err := r.BaseReplicator.CheckReplicationSlotStatus(ctx); err != nil {
-		return fmt.Errorf("failed to check replication slot status: %v", err)
-	}
-
-	return nil
-}
-
-// getStartLSN determines the starting LSN for replication.
-func (r *StreamReplicator) getStartLSN() (pglogrepl.LSN, error) {
-	startLSN, err := r.BaseReplicator.GetLastState()
-	if err != nil {
-		r.Logger.Warn().Err(err).Msg("Failed to get last LSN, starting from 0")
-		return pglogrepl.LSN(0), nil
-	}
-	return startLSN, nil
+func (r *StreamReplicator) Stop(ctx context.Context) error {
+	return r.BaseReplicator.Stop(ctx)
 }


### PR DESCRIPTION
Caller can now use it like this:

```go
ctx, cancel := context.WithCancel(context.Background())
defer cancel()

replicator, err := factory.CreateReplicator(config, natsClient)
if err != nil {
    log.Fatal(err)
}

// Start replication
if err := replicator.Start(ctx); err != nil {
    log.Fatal(err)
}

// Handle shutdown signal
sigCh := make(chan os.Signal, 1)
signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
<-sigCh

// Stop replication
shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
defer shutdownCancel()

if err := replicator.Stop(shutdownCtx); err != nil {
    log.Error(err)
}

```