### PR TITLE
Create copy query using fully qualified table names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -25,7 +25,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -38,7 +38,7 @@ jobs:
     needs: [lint, test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -24,7 +24,7 @@ jobs:
         run: make build
 
       - name: Upload binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pg_flo-binary
           path: bin/pg_flo
@@ -51,9 +51,9 @@ jobs:
             postgres_uniqueness,
           ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pg_flo-binary
           path: bin

--- a/pkg/replicator/copy_and_stream_replicator.go
+++ b/pkg/replicator/copy_and_stream_replicator.go
@@ -249,7 +249,7 @@ func (r *CopyAndStreamReplicator) getSchemaName(tx pgx.Tx, tableName string) (st
 // buildCopyQuery constructs the SQL query for copying a range of pages from a table.
 func (r *CopyAndStreamReplicator) buildCopyQuery(tableName string, schema string, startPage, endPage uint32) string {
 	// maybe we need to add schema here! - to comply with fully qualified names.
-	fullyQualifiedTableName := fmt.Sprintf("%s.%s", schema, tableName)
+	fullyQualifiedTableName := fmt.Sprintf("\"%s\".\"%s\"", schema, tableName)
 	query := fmt.Sprintf(`
 			SELECT *
 			FROM %s

--- a/pkg/replicator/copy_and_stream_replicator.go
+++ b/pkg/replicator/copy_and_stream_replicator.go
@@ -223,7 +223,7 @@ func (r *CopyAndStreamReplicator) CopyTableRange(ctx context.Context, tableName 
 		return 0, err
 	}
 
-	query := r.buildCopyQuery(tableName, startPage, endPage)
+	query := r.buildCopyQuery(tableName, schema, startPage, endPage)
 	return r.executeCopyQuery(ctx, tx, query, schema, tableName, workerID)
 }
 
@@ -247,12 +247,14 @@ func (r *CopyAndStreamReplicator) getSchemaName(tx pgx.Tx, tableName string) (st
 }
 
 // buildCopyQuery constructs the SQL query for copying a range of pages from a table.
-func (r *CopyAndStreamReplicator) buildCopyQuery(tableName string, startPage, endPage uint32) string {
+func (r *CopyAndStreamReplicator) buildCopyQuery(tableName string, schema string, startPage, endPage uint32) string {
+	// maybe we need to add schema here! - to comply with fully qualified names.
+	fullyQualifiedTableName := fmt.Sprintf("%s.%s", schema, tableName)
 	query := fmt.Sprintf(`
 			SELECT *
 			FROM %s
 			WHERE ctid >= '(%d,0)'::tid AND ctid < '(%d,0)'::tid`,
-		pgx.Identifier{tableName}.Sanitize(), startPage, endPage)
+		pgx.Identifier{fullyQualifiedTableName}.Sanitize(), startPage, endPage)
 	return query
 }
 

--- a/pkg/replicator/copy_and_stream_replicator.go
+++ b/pkg/replicator/copy_and_stream_replicator.go
@@ -248,13 +248,11 @@ func (r *CopyAndStreamReplicator) getSchemaName(tx pgx.Tx, tableName string) (st
 
 // buildCopyQuery constructs the SQL query for copying a range of pages from a table.
 func (r *CopyAndStreamReplicator) buildCopyQuery(tableName string, schema string, startPage, endPage uint32) string {
-	// maybe we need to add schema here! - to comply with fully qualified names.
-	fullyQualifiedTableName := fmt.Sprintf("\"%s\".\"%s\"", schema, tableName)
 	query := fmt.Sprintf(`
 			SELECT *
 			FROM %s
 			WHERE ctid >= '(%d,0)'::tid AND ctid < '(%d,0)'::tid`,
-		pgx.Identifier{fullyQualifiedTableName}.Sanitize(), startPage, endPage)
+		pgx.Identifier{schema, tableName}.Sanitize(), startPage, endPage)
 	return query
 }
 


### PR DESCRIPTION
Discussion reference: https://github.com/pgflo/pg_flo/discussions/66#discussioncomment-12069156

## TLDR
- During testing migrations; the copy query without the fully qualified names was breaking as postgres wasn't able to find the table
```
2025-02-04 15:42:29 [cloudwatch]  15:42:29.337 ERR Failed to copy table range error="failed to execute initial copy query: ERROR: relation \"users\" does not exist (SQLSTATE 42P01)" component=replicator
```
- Also with newer versions of Postgres; the trend is exclusively going in the direction of using fully qualified names.
- This becomes even more important in the case of managing bulk migrations. 

I have tested this in my testing environment, where I was testing if I can use pg_flo for my use case, as highlighted in the discussion, and after making this change to get the copy query using fully qualified names; the tool now works like a charm!

Let me know if you have more concerns about this change. 