### PR TITLE
add exclude_column rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,11 +187,17 @@ Rules are defined in a separate YAML file:
 
 ```yaml
 # rules.yaml
-users:
-  - type: exclude_columns
-    columns: [password, ssn]
-  - type: mask_columns
-    columns: [email]
+tables:
+    users:
+      - type: exclude_column
+        columns: password
+      - type: exclude_column
+        columns: ssn
+      - type: transform
+        column: email
+        parameters:
+          type: mask
+          mask_char: "*"
 ```
 
 ```shell

--- a/pkg/rules/engine.go
+++ b/pkg/rules/engine.go
@@ -74,6 +74,8 @@ func createRule(tableName string, config RuleConfig) (Rule, error) {
 		return NewTransformRule(tableName, config.Column, config.Parameters)
 	case "filter":
 		return NewFilterRule(tableName, config.Column, config.Parameters)
+	case "exclude_column":
+		return NewExcludeColumnRule(tableName, config.Column)
 	default:
 		return nil, fmt.Errorf("unknown rule type: %s", config.Type)
 	}

--- a/pkg/rules/types.go
+++ b/pkg/rules/types.go
@@ -43,6 +43,11 @@ type FilterRule struct {
 	AllowEmptyDeletes bool
 }
 
+type ExcludeColumnRule struct {
+	TableName  string
+	ColumnName string
+}
+
 // RuleEngine manages and applies rules to data
 type RuleEngine struct {
 	Rules map[string][]Rule // map of table name to slice of rules

--- a/pkg/utils/cdc_message.go
+++ b/pkg/utils/cdc_message.go
@@ -106,6 +106,25 @@ func (m *CDCMessage) SetColumnValue(columnName string, value interface{}) error 
 	return nil
 }
 
+// RemoveColumn removes a column from the message
+func (m *CDCMessage) RemoveColumn(columnName string) error {
+	colIndex := m.GetColumnIndex(columnName)
+	if colIndex == -1 {
+		return fmt.Errorf("column %s not found", columnName)
+	}
+
+	m.Columns = append(m.Columns[:colIndex], m.Columns[colIndex+1:]...)
+	if m.NewTuple != nil {
+		m.NewTuple.ColumnNum--
+		m.NewTuple.Columns = append(m.NewTuple.Columns[:colIndex], m.NewTuple.Columns[colIndex+1:]...)
+	}
+	if m.OldTuple != nil {
+		m.OldTuple.ColumnNum--
+		m.OldTuple.Columns = append(m.OldTuple.Columns[:colIndex], m.OldTuple.Columns[colIndex+1:]...)
+	}
+	return nil
+}
+
 // EncodeCDCMessage encodes a CDCMessage into a byte slice
 func EncodeCDCMessage(m CDCMessage) ([]byte, error) {
 	var buf bytes.Buffer


### PR DESCRIPTION
Hi, I've just about got pg_flow working and ran into an issue with a generated column. It can't be inserted on the target side so I wanted to exclude the entire column.

Unfortunately, the readme mentioned a filter rule that didn't exist.. so I implemented it. I changed it slightly from "columns" to "column" to avoid ambiguity that would cause with other rules. I also fixed the rules.yaml doc on the README that was missing the "tables:" key and was quite confusing.

Please let me know if there's anything else this should cover.