### PR TITLE
Ignore error on removing column that doesn't exist

### DIFF
--- a/pkg/rules/engine.go
+++ b/pkg/rules/engine.go
@@ -23,12 +23,6 @@ func (re *RuleEngine) ApplyRules(message *utils.CDCMessage) (*utils.CDCMessage, 
 		return message, nil // No rules for this table
 	}
 
-	logger.Info().
-		Str("table", message.Table).
-		Str("operation", string(message.Type)).
-		Int("ruleCount", len(rules)).
-		Msg("Applying rules")
-
 	var err error
 	for _, rule := range rules {
 		message, err = rule.Apply(message)

--- a/pkg/utils/cdc_message.go
+++ b/pkg/utils/cdc_message.go
@@ -27,6 +27,10 @@ func init() {
 	gob.Register(pglogrepl.TupleDataColumn{})
 }
 
+type ColumnNotFoundError struct {
+	ColumnName string
+}
+
 // CDCMessage represents a full message for Change Data Capture
 type CDCMessage struct {
 	Type           OperationType
@@ -109,11 +113,15 @@ func (m *CDCMessage) SetColumnValue(columnName string, value interface{}) error 
 	return nil
 }
 
+func (e ColumnNotFoundError) Error() string {
+	return fmt.Sprintf("column %s not found", e.ColumnName)
+}
+
 // RemoveColumn removes a column from the message
 func (m *CDCMessage) RemoveColumn(columnName string) error {
 	colIndex := m.GetColumnIndex(columnName)
 	if colIndex == -1 {
-		return fmt.Errorf("column %s not found", columnName)
+		return ColumnNotFoundError{columnName}
 	}
 
 	newColumns := make([]*pglogrepl.RelationMessageColumn, len(m.Columns))


### PR DESCRIPTION
This PR ignores an error when applying exclude column rules. I had an issue where generated columns are selected during copy but aren't present in the wal log (pg design). So excluding them worked for copy but when streaming it made an error.

Also a minor log change because "applying rules" was overwhelming the logging infra.